### PR TITLE
Fix shallow merging of config defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function HtmlBeautifyPlugin ({ config = {}, replace } = { config: {}, replace: [
 	assert(config && typeof config === 'object' , chalk.red('Beautify config should be an object.'))
 
 	this.options = {
-		config: _.extend({
+		config: _.merge({
 			indent_size: 4,
 			indent_with_tabs: false,
 			html: {


### PR DESCRIPTION
Hi there,

I was looking through the source code of this package and noticed it was using `_.extend` to merge the default config with the user config. `_.extend` does a shallow merge (one level deep). This would normally be fine, but in this case you've got a nested object in the config: `config.html`.

If a user specifies just one property in the `config.html` object:

```js
new HtmlBeautifyPlugin({
    config: {
        html: {
            indent_inner_html: false
        }
    }
})
```

Then their version of `config.html` would override the default `config.html` entirely, and the other two properties (`end_with_newline`, `preserve_newlines`) would not be present on the resulting object.

You can use [`_.merge`](https://lodash.com/docs/4.17.4#merge) to do a deep merge, which should fix this potential problem. This PR applies that change. Sorry about the added line at the end of the file; the GitHub editor did this automatically. I can update the PR to remove it if it's an issue.

P.S.
I wrote some [TypeScript](https://www.typescriptlang.org/) type definitions for this package. If you'd like, I can open a PR to add them to the repo (as a separate `.d.ts` file). Alternatively, I can open a PR at the community-maintained type definitions repo [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) to add them there.