### PR TITLE
Add html-webpack-plugin v4 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin')
 const webpack = require('webpack')
 const _ = require('lodash')
 const chalk = require('chalk')
@@ -42,11 +43,18 @@ HtmlBeautifyPlugin.prototype.apply = function (compiler) {
             })
         )
     } else {
-        compiler.hooks.compilation.tap('HtmlBeautifyPlugin', compilation =>
-            compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync('HtmlBeautifyPlugin', (htmlPluginData, callback) => {
-                htmlPluginDataFunction(htmlPluginData, callback, this)
-            })
-        )
+        compiler.hooks.compilation.tap('HtmlBeautifyPlugin', (compilation) =>
+            HtmlWebpackPlugin.getHooks
+                ? HtmlWebpackPlugin.getHooks(compilation).afterTemplateExecution.tapAsync(
+                      'HtmlBeautifyPlugin',
+                      (htmlPluginData, callback) => {
+                          htmlPluginDataFunction(htmlPluginData, callback, this);
+                      },
+                  )
+                : compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync('HtmlBeautifyPlugin', (htmlPluginData, callback) => {
+                      htmlPluginDataFunction(htmlPluginData, callback, this);
+                  }),
+        );
     }
 }
 


### PR DESCRIPTION
Adds support of the [html-webpack-plugin][] v4 as the `v4.0.0` has introduced the new hooks. Should also work with previous versions as well and fix the https://github.com/seeyoulater/html-beautify-webpack-plugin/issues/9.

Was tested using the following [html-webpack-plugin][] versions: `3.2.0`, `4.0.0` and `4.3.0`.

[html-webpack-plugin]: https://github.com/jantimon/html-webpack-plugin